### PR TITLE
add --port parameter for zenbot's server plugin

### DIFF
--- a/core/commands/launch.json
+++ b/core/commands/launch.json
@@ -11,6 +11,11 @@
       "name": "verbose",
       "spec": "-v, --verbose",
       "description": "output runner debug info"
-    }
+    },
+	{
+	  "name": "port",
+	  "spec": "-p, --port <port>",
+	  "description": "port to listen on"
+	}
   ]
 }


### PR DESCRIPTION
this change allows to launch (with "zenbot launch server --port ...") zenbot's server plugin on a custom port in the same way as "zenbot server --port ..." does...
